### PR TITLE
available_quantity -> _purchased_quantity in snippet

### DIFF
--- a/chapter_01_domain_model.asciidoc
+++ b/chapter_01_domain_model.asciidoc
@@ -542,7 +542,7 @@ class Batch:
     def __init__(self, ref: Reference, sku: Sku, qty: Quantity):
         self.sku = sku
         self.reference = ref
-        self.available_quantity = qty
+        self._purchased_quantity = qty
 ----
 ====
 


### PR DESCRIPTION
By this point in the chapter, `available_quantity` is a property instead of a member variable, and been replace by `_purchased_quantity`.  It's a little bit confusing if you're skimming back and forth.