### PR TITLE
use logging lib instead of print, use logging.exception

### DIFF
--- a/chapter_06_aggregate.asciidoc
+++ b/chapter_06_aggregate.asciidoc
@@ -589,7 +589,7 @@ def try_to_allocate(orderid, sku, exceptions):
             time.sleep(0.2)
             uow.commit()
     except Exception as e:
-        print(traceback.format_exc())
+        logging.exception("Swallowing unexpected exception in 'try_to_allocate'")
         exceptions.append(e)
 ----
 ====

--- a/chapter_06_aggregate.asciidoc
+++ b/chapter_06_aggregate.asciidoc
@@ -589,7 +589,7 @@ def try_to_allocate(orderid, sku, exceptions):
             time.sleep(0.2)
             uow.commit()
     except Exception as e:
-        logging.exception("Swallowing unexpected exception in 'try_to_allocate'")
+        print(traceback.format_exc())
         exceptions.append(e)
 ----
 ====

--- a/chapter_09_commands.asciidoc
+++ b/chapter_09_commands.asciidoc
@@ -126,9 +126,9 @@ def handle_command(command, uow: unit_of_work.AbstractUnitOfWork):  #<3>
     try:
         handler = COMMAND_HANDLERS[type(command)]
         return handler(command, uow=uow)
-    except Exception as e:
+    except Exception:
         logging.exception('Exception handling command %s', command)
-        raise e  #<3>
+        raise  #<3>
 
 
 EVENT_HANDLERS = {

--- a/chapter_09_commands.asciidoc
+++ b/chapter_09_commands.asciidoc
@@ -114,20 +114,20 @@ def handle(message: Message, uow: unit_of_work.AbstractUnitOfWork):  #<1>
 def handle_event(event: events.Event, uow: unit_of_work.AbstractUnitOfWork):  #<2>
     for handler in EVENT_HANDLERS[type(event)]:
         try:
-            print('handling event', event, 'with handler', handler, flush=True)
+            logging.debug('handling event %s with handler %s', event, handler)
             handler(event, uow=uow)
         except:  #<2>
-            print(f'Exception handling event {event}\n:{traceback.format_exc()}')
+            logging.exception('Exception handling event %s', event)
             continue
 
 
 def handle_command(command, uow: unit_of_work.AbstractUnitOfWork):  #<3>
-    print('handling command', command, flush=True)
+    logging.debug('handling command %s', command)
     try:
         handler = COMMAND_HANDLERS[type(command)]
         return handler(command, uow=uow)
     except Exception as e:
-        print(f'Exception handling command {command}: {e}')
+        logging.exception('Exception handling command %s', command)
         raise e  #<3>
 
 
@@ -368,10 +368,10 @@ Let's look again at the 'handle_event' method from our message bus.
 def handle_event(event: events.Event, uow: unit_of_work.AbstractUnitOfWork):
     for handler in EVENT_HANDLERS[type(event)]:
         try:
-            print('handling event', event, 'with handler', handler, flush=True)
+            logging.debug('handling event %s with handler %s', event, handler)
             handler(event, uow=uow)
         except:
-            print(f'Exception handling event {event}\n:{traceback.format_exc()}')
+            logging.exception('Exception handling event %s', event)
             continue
 ----
 ====
@@ -426,7 +426,7 @@ def handle_event(event: events.Event, uow: unit_of_work.AbstractUnitOfWork):
             ):
 
                 with attempt:
-                  print('handling event', event, 'with handler', handler)
+                  logging.debug('handling event %s with handler %s', event, handler)
                   handler(event, uow=uow)
         except RetryError:
             print('Failed to handle event, retrying')

--- a/chapter_12_dependency_injection.asciidoc
+++ b/chapter_12_dependency_injection.asciidoc
@@ -251,7 +251,7 @@ What else changes in the bus?
             self.call_handler_with_dependencies(handler, command)  #<2>
         except Exception:
             logging.exception('Exception handling command %s', command)
-            raise e
+            raise
 ----
 ====
 

--- a/chapter_12_dependency_injection.asciidoc
+++ b/chapter_12_dependency_injection.asciidoc
@@ -230,8 +230,6 @@ class MessageBus:  #<1>
 
 What else changes in the bus? 
 
-// TODO: print -> logging.debug
-
 [[messagebus_handlers_change]]
 .Event and Command handler logic stays the same (src/allocation/messagebus.py)
 ====
@@ -240,19 +238,19 @@ What else changes in the bus?
     def handle_event(self, event: events.Event):  #<1>
         for handler in EVENT_HANDLERS[type(event)]:
             try:
-                print('handling event', event, 'with handler', handler, flush=True)
+                logging.debug('handling event %s with handler %s', event, handler)
                 self.call_handler_with_dependencies(handler, event)  #<2>
             except:
-                print(f'Exception handling event {event}\n:{traceback.format_exc()}')
+                logging.exception('Exception handling event %s', event)
                 continue
 
     def handle_command(self, command: commands.Command):  #<1>
-        print('handling command', command, flush=True)
+        logging.debug('handling command %s', command)
         try:
             handler = COMMAND_HANDLERS[type(command)]
             self.call_handler_with_dependencies(handler, command)  #<2>
-        except Exception as e:
-            print(f'Exception handling command {command}: {e}')
+        except Exception:
+            logging.exception('Exception handling command %s', command)
             raise e
 ----
 ====


### PR DESCRIPTION
A couple things that might be worth pointing out, in the spirit of  being Enterprisey:
* using the logger args instead of f-strings will prevent a buggy `__str__` implementation from crashing your program
* `logging.exception` will include the traceback automatically
