### PR TITLE
make gubbins pseudo-code syntax consistent with real

### DIFF
--- a/chapter_02_repository.asciidoc
+++ b/chapter_02_repository.asciidoc
@@ -443,9 +443,9 @@ def allocate_endpoint():
 
     # extract order line from request
     line = OrderLine(
-        request.params['order_id'],
-        request.params['sku'],
-        request.params['qty'],
+        request.json['orderid'],
+        request.json['sku'],
+        request.json['qty'],
     )
 
     # load all batches from the DB


### PR DESCRIPTION
Changed to match real implementation in following code, and also use normal Flask syntax.  (`request.params` is not a thing unless you install this [lib](https://flask-request-params.readthedocs.io/en/latest/)?)