### PR TITLE
Add docker image for building HTML using asciidoctor

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM asciidoctor/docker-asciidoctor
+
+RUN apk update && apk add --no-cache \
+	git \
+	python3 \
+	py-pip \
+	py-setuptools
+
+RUN gem install pygments.rb
+RUN gem install asciidoctor-diagram
+
+RUN pip install --user pygments

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,11 @@
+COMPOSE_ASCIIDOCTOR = docker-compose run --rm asciidoctor
+
+prepare:
+	docker-compose build
+
+html_docker: prepare
+	$(COMPOSE_ASCIIDOCTOR) asciidoctor -a stylesheet=theme/asciidoctor.local.css -a source-highlighter=pygments -a '!example-caption' *.asciidoc
+
 html:
 	asciidoctor -a stylesheet=theme/asciidoctor.local.css -a source-highlighter=pygments -a '!example-caption' *.asciidoc
 

--- a/Readme.md
+++ b/Readme.md
@@ -62,3 +62,8 @@ make html  # builds local .html versions of each chapter
 make test  # does a sanity-check of the code listings
 ```
 
+For building HTML pages using Docker containers:
+
+```sh
+make html_docker
+```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,11 @@
+version: "3.7"
+services:
+  asciidoctor:
+    build: 
+      context: . 
+      dockerfile: Dockerfile
+    volumes:
+      - .:/documents/
+
+volumes:
+  book-data:


### PR DESCRIPTION
For easily building HTML versions of ascii docs without installing the dependencies listed in the README.md file I am proposing the use of docker images, similar to a [3 Muskeeters approach](https://3musketeers.io/docs/docker.html)

For building HTML pages with Docker, just run:

```sh
make html_docker
```

This can be extended to other commands.
