### PR TITLE
fix a grep command

### DIFF
--- a/chapter_05_high_gear_low_gear.asciidoc
+++ b/chapter_05_high_gear_low_gear.asciidoc
@@ -48,7 +48,7 @@ does to our test pyramid:
 [source,sh]
 [role="skip"]
 ----
-$ grep -c test_ test_*.py
+$ grep -c test_ **/test_*.py
 tests/unit/test_allocate.py:4
 tests/unit/test_batches.py:8
 tests/unit/test_services.py:3


### PR DESCRIPTION
when I try to type `grep -c test_ test_*.py`, I get `zsh: no matches found: test_*.py`.
and I try `grep -c test_ **/test_*.py` can get correct result