### PR TITLE
Small fix to text formatting in Chapter 7

### DIFF
--- a/chapter_07_aggregate.asciidoc
+++ b/chapter_07_aggregate.asciidoc
@@ -372,7 +372,7 @@ class Product:
 ----
 ====
 
-<1> `Product`'s main identifier is the `sku`.
+<1> ``Product``'s main identifier is the `sku`.
 
 <2> Our `Product` class holds a reference to a collection of `batches` for that SKU.
     ((("allocate service", "moving to be a method on Product aggregate")))


### PR DESCRIPTION
A small fix to text formatting in Chapter 7. To understand why, see example 9 in https://docs.asciidoctor.org/asciidoc/latest/syntax-quick-reference/#text-formatting.