### PR TITLE
RFC: Create local transaction context in Django

### DIFF
--- a/appendix_django.asciidoc
+++ b/appendix_django.asciidoc
@@ -306,30 +306,25 @@ would work:
 class DjangoUnitOfWork(AbstractUnitOfWork):
     def __enter__(self):
         self.batches = repository.DjangoRepository()
-        transaction.set_autocommit(False)  #<1>
         return super().__enter__()
 
     def __exit__(self, *args):
         super().__exit__(*args)
-        transaction.set_autocommit(True)
 
     def commit(self):
-        for batch in self.batches.seen:  #<3>
-            self.batches.update(batch)  #<3>
-        transaction.commit()  #<2>
+        with transaction.atomic():  #<1>
+            for batch in self.batches.seen:  #<2>
+                self.batches.update(batch)  #<2>
 
     def rollback(self):
-        transaction.rollback()  #<2>
+        pass
 ----
 ====
 
-<1> `set_autocommit(False)` was the best way to tell Django to stop
-    automatically committing each ORM operation immediately, and to
-    begin a transaction.
+<1> Override global Django's auto-commit behavior by creating
+    a local transaction context.
 
-<2> Then we use the explicit rollback and commits.
-
-<3> One difficulty: because, unlike with SQLAlchemy, we're not
+<2> One difficulty: because, unlike with SQLAlchemy, we're not
     instrumenting the domain model instances themselves, the
     `commit()` command needs to explicitly go through all the
     objects that have been touched by every repository and manually


### PR DESCRIPTION
In Django UoW, it creates a transaction by configuring global auto-commit flag. 
Configuring a global flag here is not desirable, and it might not work as expected
if another Django thread tampers the flag at the same time. 

This PR fixes the problem by creating a local transaction context using 
[`transaction.atomic()`][1]. 

PS. I havn't tested the code yet. 

[1]: https://docs.djangoproject.com/en/3.2/topics/db/transactions/#django.db.transaction.atomic