### PR TITLE
Update part1.asciidoc

### DIFF
--- a/part1.asciidoc
+++ b/part1.asciidoc
@@ -32,7 +32,7 @@ To do that, we present four key design patterns:
 * The <<chapter_02_repository,Repository pattern>>, an abstraction over the
   idea of persistent storage
 
-* The <<chapter_04_service_layer,Service Layer>> pattern to clearly define where our
+* The <<chapter_04_service_layer,Service Layer pattern>> to clearly define where our
   use cases begin and end
   
 [role="pagebreak-before"]


### PR DESCRIPTION
Change of link to Service Layer pattern.

Link should be for words "Service Layer pattern" as with other patterns and not only for words "Service Layer".