### PR TITLE
Makes FakeRepository from Ch5 more like one from Ch2

### DIFF
--- a/chapter_05_high_gear_low_gear.asciidoc
+++ b/chapter_05_high_gear_low_gear.asciidoc
@@ -310,7 +310,7 @@ function on `FakeRepository`:
 [source,python]
 [role="skip"]
 ----
-class FakeRepository(set):
+class FakeRepository(repository.AbstractRepository):
 
     @staticmethod
     def for_batch(ref, sku, qty, eta=None):


### PR DESCRIPTION
It looks like `FakeRepository` in Chapter 5 introduced in 50bfa5c  was left in original state, while in the meantime ABC was introduced into chapter 2 in 1795366, so here we make it match again.

As a side note, the alternative approach would be to use `classmethod` instead of `staticmethod` but it depends very much on personal preferences. It's **not** what I propose in that PR, but it could look like that:

```python
class FakeRepository(repository.AbstractRepository):
    @classmethod
    def for_batch(cls, ref, sku, qty, eta=None):
        return cls([model.Batch(ref, sku, qty, eta)])
``` 