### PR TITLE
Fix a minor syntax error in asciidoctor-clean.custom.css

### DIFF
--- a/theme/asciidoctor-clean.custom.css
+++ b/theme/asciidoctor-clean.custom.css
@@ -89,3 +89,4 @@ table {
   width: 55vw!important;
   font-size: 3vw;
 }
+}


### PR DESCRIPTION
Although all browsers will render the generated HTML files correctly even if they are missing a curly bracket, it's better to fix this error.